### PR TITLE
修复$mp为undefine 报错提示

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,15 +10,16 @@ function parseUrl(location) {
 }
 
 function parseRoute($mp) {
-  const path = $mp.page && $mp.page.route
+  const _$mp = $mp || {};
+  const path = _$mp.page && _$mp.page.route
   return {
     path,
     params: {},
-    query: $mp.query,
+    query: _$mp.query,
     hash: '',
     fullPath: parseUrl({
       path,
-      query: $mp.query
+      query: _$mp.query
     }),
     name: path && path.replace(/\/(\w)/g, ($0, $1) => $1.toUpperCase())
   }


### PR DESCRIPTION
webpack入口配置page不同，某些情况会出现$mp为undefined，在微信开发者工具中报红，但是不影响程序执行。