### PR TITLE
支持在模板中调用方法

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,29 @@ function back() {
   wx.navigateBack()
 }
 
+let routerMethods = {
+  push,
+  replace,
+  go,
+  back
+}
+
+// 首字母大写
+function upperCapital(word){
+  return word.replace(/^([a-z])/, (w,cap)=>cap.toUpperCase());
+}
+// 代理方法对象
+function proxyRooter(){
+  let proxyMethods = {};
+  ['push','replace','go','back'].map(method=>{
+    proxyMethods['$router' + upperCapital(method)] = function(){
+      let args = Array.prototype.slice.call(arguments);
+      routerMethods[method].apply(null,args);
+    }
+  });
+  return proxyMethods;
+}
+
 export let _Vue
 
 export default {
@@ -66,10 +89,7 @@ export default {
 
     const _router = {
       mode: 'history',
-      push,
-      replace,
-      go,
-      back
+      ...routerMethods
     }
 
     Vue.mixin({
@@ -80,6 +100,9 @@ export default {
       onShow() {
         _router.app = this
         _router.currentRoute = this._route
+      },
+      methods: {
+        ...proxyRooter()
       }
     })
 


### PR DESCRIPTION
将$router的几个方法进行了全局混合，并合并成了`$routerMethod()`的函数名称，供在模板文件中进行调用。
方法的传参方式与代理的源方法保持一致，即：
```javascript
// 字符串
$routerPush('/pages/news/detail')

// 对象
$routerPush({ path: '/pages/news/detail' })

// 带查询参数，变成 /pages/news/detail?id=1
$routerPush({ path: '/pages/news/detail', query: { id: 1 } })

// 切换至 tabBar 页面
$routerPush({ path: '/pages/news/list', isTab: true })

// 重启至某页面，无需指定是否为 tabBar 页面，但 tabBar 页面无法携带参数
$routerPush({ path: '/pages/news/list', reLaunch: true })

// 其他的方法也进行了代理
$routerGo();
$routerBack();
$routerReplace();
```